### PR TITLE
Removed too much stuff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,16 @@ buildscript {
     }
 }
 
+task webpack(type: Exec) {
+    inputs.dir("$projectDir/frontend").withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir("$buildDir/resources/main/static")
+//    outputs.dir("$projectDir/src/main/resources/static")
+    outputs.cacheIf { true }
+
+//    parcel build -d ../src/main/resources/static ./public/index.html
+    commandLine "$projectDir/frontend/node_modules/.bin/parcel.cmd", "build", "-d", "$buildDir/resources/main/static", "$projectDir/frontend/public/index.html"
+}
+
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/ace/alfox/AlfoxApplication.java
+++ b/src/main/java/com/ace/alfox/AlfoxApplication.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
+@EnableAutoConfiguration
 public class AlfoxApplication implements WebMvcConfigurer {
 
   public void addCorsMappings(CorsRegistry registry) {


### PR DESCRIPTION
So apparently `@EnableAutoConfiguration` is required if you want to serve your `index.html` file at `/` by default. In addition now there's a `webpack` gradle function to build the frontend.